### PR TITLE
added symlink to script

### DIFF
--- a/Container/install.sh
+++ b/Container/install.sh
@@ -20,4 +20,5 @@ apt-get autoremove -y
 apt-get clean
 python3.7 -m ensurepip --upgrade
 python3.7 -m pip install --upgrade pip setuptools wheel
+ln -s /usr/local/bin/python3.7 /usr/local/bin/python3
 cd /


### PR DESCRIPTION
venv commands could not be found probably because venv isn't installed.
It also expects "python" instead of "python3.7", but that can be fixed with a symlink.
Added ln -s /usr/local/bin/python3.7 /usr/local/bin/python3 to the script